### PR TITLE
Update test-validate.md - correct PayPal timeout information

### DIFF
--- a/help/payment-services/test-validate.md
+++ b/help/payment-services/test-validate.md
@@ -41,7 +41,7 @@ To expose your local environment:
 
 1. Restore your original base URL configuration when testing is complete.
 
-If the endpoint's response time is under 5 seconds, PayPal displays an error message in the pop-up.
+If the endpoint's response time is over 5 seconds, PayPal displays an error message in the pop-up.
 
 #### Apple Pay local development
 


### PR DESCRIPTION
Updates: https://experienceleague.adobe.com/en/docs/commerce/payment-services/configure/test-validate

The PayPal errors are shown when the response time is "over" 5 seconds (not under)? Correcting documentation to reflect this. 
