### PR TITLE
MDEE-1403: Replace vague propagation timing in ACO Connector troubleshooting

### DIFF
--- a/help/aco-connector/troubleshooting/troubleshooting-scenarios.md
+++ b/help/aco-connector/troubleshooting/troubleshooting-scenarios.md
@@ -45,11 +45,11 @@ This page describes behaviors you may observe when working with the [!DNL Adobe 
 
 **Issue:** The **[!UICONTROL Data Feed Sync Status]** page reports a successful sync, but products, prices, etc. are not appearing as expected in [!DNL Adobe Commerce Optimizer].
 
-**Cause:** A successful feed status means the data was accepted by the ingestion endpoint, not that it has finished propagating through [!DNL Adobe Commerce Optimizer]. Propagation can take several minutes after ingestion.
+**Cause:** A successful feed status means the data was accepted by the ingestion endpoint, not that it has finished propagating through to [!DNL Adobe Commerce Optimizer]. Uncached queries typically reflect updates within 3 minutes. Changes served through a storefront or CDN cache can take up to 20 minutes to appear.
 
 **Solution:**
 
-- Wait a few minutes and refresh the [!DNL Adobe Commerce Optimizer] view.
+- Allow up to 20 minutes for propagation and for any storefront or CDN cache to refresh, then reload the [!DNL Adobe Commerce Optimizer] view. Uncached queries typically update within 3 minutes. If the data is still missing after 20 minutes, continue with the checks below and open a support ticket if unresolved.
 - Confirm that the tenant ID configured in [!DNL Adobe Commerce] matches the [!DNL Commerce Optimizer] environment you are checking.
 - Verify that the correct [catalog source](../../optimizer/setup/catalog-sources.md) (store view code) or price book is selected in [!DNL Commerce Optimizer].
 


### PR DESCRIPTION
## What

Updates the *"Feed status shows Success but data is not visible in Adobe Commerce Optimizer"* troubleshooting scenario to replace vague timing ("a few minutes" / "several minutes") with concrete, actionable propagation windows.

## Why

Per [MDEE-1403](https://jira.corp.adobe.com/browse/MDEE-1403): the existing "a few minutes" guidance is too vague to be actionable. Users have no upper bound and no signal for when to stop waiting and escalate.

## Changes

- **Cause:** now distinguishes the uncached path (updates typically reflect within 3 minutes) from the cached path (storefront/CDN cache can take up to 20 minutes). Also corrects "propagating through" to "propagating through to".
- **Solution:** first step now gives a concrete 20-minute wait window, a 3-minute typical for uncached queries, and an escalation threshold (open a support ticket if still missing after 20 minutes).

Timing figures are sourced from the cross-team PaaS prod SLO dashboard. Wording uses "typically" since there is no published public SLO, so this reads as expected behavior rather than a guarantee.

Ref: MDEE-1403